### PR TITLE
Implement Firestore RBAC and onboarding persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ The application is designed with a $5/month per client portal revenue model:
 
 - Firebase Authentication for secure user management
 - Role-based access control
+- Firestore security rules enforce onboarding completion and per-user data ownership
 - Secure file uploads and downloads
 - Client portal isolation
 - HTTPS enforcement

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,46 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function getUser() {
+      return get(/databases/$(database)/documents/users/$(request.auth.uid)).data;
+    }
+    function isSignedIn() {
+      return request.auth != null;
+    }
+    function onboardingComplete() {
+      return getUser().onboardingCompleted == true;
+    }
+    function hasRole(role) {
+      return getUser().role == role;
+    }
+
+    match /users/{userId} {
+      allow read, write: if isSignedIn() && request.auth.uid == userId;
+    }
+
+    match /clients/{clientId} {
+      allow create: if isSignedIn() && onboardingComplete() && (hasRole('admin') || hasRole('freelancer')) && request.resource.data.ownerId == request.auth.uid;
+      allow read: if isSignedIn() && onboardingComplete() && resource.data.ownerId == request.auth.uid;
+      allow update, delete: if isSignedIn() && onboardingComplete() && resource.data.ownerId == request.auth.uid && (hasRole('admin') || hasRole('freelancer'));
+    }
+
+    match /projects/{projectId} {
+      allow read: if isSignedIn() && onboardingComplete();
+      allow create, update, delete: if isSignedIn() && onboardingComplete() && !hasRole('client');
+    }
+
+    match /invoices/{invoiceId} {
+      allow read: if isSignedIn() && onboardingComplete();
+      allow create, update, delete: if isSignedIn() && onboardingComplete() && (hasRole('admin') || hasRole('freelancer'));
+    }
+
+    match /files/{fileId} {
+      allow read: if isSignedIn() && onboardingComplete();
+      allow write: if isSignedIn() && onboardingComplete() && (hasRole('admin') || hasRole('freelancer') || hasRole('team_member'));
+    }
+
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,17 +24,53 @@ function App() {
       <div className="min-h-screen bg-gray-50">
         <Routes>
           {/* Public routes */}
-          <Route path="/login" element={!currentUser ? <Login /> : <Navigate to="/dashboard" />} />
-          <Route path="/signup" element={!currentUser ? <Signup /> : <Navigate to="/dashboard" />} />
+            <Route
+              path="/login"
+              element={
+                !currentUser
+                  ? <Login />
+                  : currentUser.onboardingCompleted
+                    ? <Navigate to="/dashboard" />
+                    : <Navigate to="/onboarding" />
+              }
+            />
+            <Route
+              path="/signup"
+              element={
+                !currentUser
+                  ? <Signup />
+                  : currentUser.onboardingCompleted
+                    ? <Navigate to="/dashboard" />
+                    : <Navigate to="/onboarding" />
+              }
+            />
           
           {/* Onboarding route */}
-          <Route path="/onboarding" element={currentUser ? <Onboarding /> : <Navigate to="/login" />} />
+            <Route
+              path="/onboarding"
+              element={
+                currentUser
+                  ? currentUser.onboardingCompleted
+                    ? <Navigate to="/dashboard" />
+                    : <Onboarding />
+                  : <Navigate to="/login" />
+              }
+            />
           
           {/* Client portal route */}
           <Route path="/portal/:clientId" element={<ClientPortal />} />
           
           {/* Protected routes */}
-          <Route path="/" element={currentUser ? <Layout /> : <Navigate to="/login" />}>
+            <Route
+              path="/"
+              element={
+                currentUser
+                  ? currentUser.onboardingCompleted
+                    ? <Layout />
+                    : <Navigate to="/onboarding" />
+                  : <Navigate to="/login" />
+              }
+            >
             <Route index element={<Navigate to="/dashboard" />} />
             <Route path="dashboard" element={<Dashboard />} />
             <Route path="clients" element={<Clients />} />

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -7,6 +7,7 @@ import {
 } from 'lucide-react';
 import { getClients } from '../firebase/clients';
 import { getFiles } from '../firebase/files';
+import { useAuth } from '../contexts/AuthContext';
 
 interface AnalyticsData {
   totalRevenue: number;
@@ -19,8 +20,8 @@ interface AnalyticsData {
   fileUploads: { month: string; uploads: number }[];
 }
 
-function Analytics() {
-  const [analyticsData, setAnalyticsData] = useState<AnalyticsData>({
+  function Analytics() {
+    const [analyticsData, setAnalyticsData] = useState<AnalyticsData>({
     totalRevenue: 0,
     totalClients: 0,
     totalProjects: 0,
@@ -30,16 +31,18 @@ function Analytics() {
     projectStatus: [],
     fileUploads: []
   });
-  const [isLoading, setIsLoading] = useState(true);
-  const [timeRange, setTimeRange] = useState<'7d' | '30d' | '90d' | '1y'>('30d');
+    const [isLoading, setIsLoading] = useState(true);
+    const [timeRange, setTimeRange] = useState<'7d' | '30d' | '90d' | '1y'>('30d');
+    const { currentUser } = useAuth();
 
   useEffect(() => {
-    const fetchAnalyticsData = async () => {
-      try {
-        setIsLoading(true);
+      const fetchAnalyticsData = async () => {
+        if (!currentUser) return;
+        try {
+          setIsLoading(true);
         
         // Fetch real data from Firebase
-        const clients = await getClients();
+          const clients = await getClients(currentUser.id);
         const files = await getFiles();
         
         // Calculate analytics from real data
@@ -92,7 +95,7 @@ function Analytics() {
     };
 
     fetchAnalyticsData();
-  }, [timeRange]);
+    }, [timeRange, currentUser]);
 
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat('en-US', {

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -32,7 +32,7 @@ interface OnboardingForm {
 function Onboarding() {
   const [currentStep, setCurrentStep] = useState(1);
   const [selectedRole, setSelectedRole] = useState<'client' | 'admin' | null>(null);
-  const { currentUser, updateUserRole } = useAuth();
+  const { currentUser, updateUserRole, completeOnboarding } = useAuth();
   const navigate = useNavigate();
 
   const {
@@ -59,15 +59,12 @@ function Onboarding() {
 
   const onSubmit = async (data: OnboardingForm) => {
     try {
-      // Update user role and complete onboarding
-      updateUserRole(data.role);
-      
-      // In a real app, you'd save this to Firebase
-      // For now, we'll just simulate the completion
-      
+      await updateUserRole(data.role);
+      await completeOnboarding();
+
       toast.success('Onboarding completed successfully!');
       setCurrentStep(5);
-      
+
       // Redirect after a short delay
       setTimeout(() => {
         navigate('/dashboard');

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,22 +1,23 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { 
-  User as FirebaseUser, 
-  signInWithEmailAndPassword, 
-  createUserWithEmailAndPassword, 
-  signOut, 
-  onAuthStateChanged 
+import {
+  User as FirebaseUser,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut,
+  onAuthStateChanged
 } from 'firebase/auth';
-import { auth } from '../firebase/config';
+import { doc, getDoc, setDoc, updateDoc, serverTimestamp } from 'firebase/firestore';
+import { auth, db } from '../firebase/config';
 import { User, UserRole } from '../types/auth';
 
 interface AuthContextType {
   currentUser: User | null;
-  login: (email: string, password: string) => Promise<void>;
-  signup: (email: string, password: string, name: string, role?: UserRole) => Promise<void>;
+  login: (email: string, password: string) => Promise<User>;
+  signup: (email: string, password: string, name: string, role?: UserRole) => Promise<User>;
   logout: () => Promise<void>;
   loading: boolean;
-  updateUserRole: (role: UserRole) => void;
-  completeOnboarding: () => void;
+  updateUserRole: (role: UserRole) => Promise<void>;
+  completeOnboarding: () => Promise<void>;
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -33,39 +34,73 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
-  function signup(email: string, password: string, name: string, role: UserRole = 'freelancer') {
-    return createUserWithEmailAndPassword(auth, email, password).then((result) => {
-      // Create custom user object with role
-      const customUser: User = {
-        id: result.user.uid,
-        email: result.user.email || '',
-        name,
-        role,
-        permissions: [],
-        createdAt: new Date(),
-        onboardingCompleted: false,
-        onboardingStep: 1,
-      };
-      setCurrentUser(customUser);
+  async function signup(email: string, password: string, name: string, role: UserRole = 'freelancer') {
+    const result = await createUserWithEmailAndPassword(auth, email, password);
+    const userRef = doc(db, 'users', result.user.uid);
+    const customUser: User = {
+      id: result.user.uid,
+      email: result.user.email || '',
+      name,
+      role,
+      permissions: [],
+      createdAt: new Date(),
+      onboardingCompleted: false,
+      onboardingStep: 1,
+    };
+    await setDoc(userRef, {
+      email: customUser.email,
+      name: customUser.name,
+      role: customUser.role,
+      permissions: customUser.permissions,
+      createdAt: serverTimestamp(),
+      onboardingCompleted: false,
+      onboardingStep: 1,
     });
+    setCurrentUser(customUser);
+    return customUser;
   }
 
-  function login(email: string, password: string) {
-    return signInWithEmailAndPassword(auth, email, password).then((result) => {
-      // For now, create a default user object
-      // In a real app, you'd fetch user data from Firestore
-      const customUser: User = {
+  async function login(email: string, password: string) {
+    const result = await signInWithEmailAndPassword(auth, email, password);
+    const userRef = doc(db, 'users', result.user.uid);
+    const snapshot = await getDoc(userRef);
+
+    let customUser: User;
+    if (snapshot.exists()) {
+      const data = snapshot.data();
+      customUser = {
+        id: result.user.uid,
+        email: data.email || '',
+        name: data.name || result.user.displayName || 'User',
+        role: data.role || 'freelancer',
+        permissions: data.permissions || [],
+        createdAt: data.createdAt?.toDate?.() || new Date(),
+        onboardingCompleted: data.onboardingCompleted || false,
+        onboardingStep: data.onboardingStep || 1,
+      };
+    } else {
+      customUser = {
         id: result.user.uid,
         email: result.user.email || '',
         name: result.user.displayName || 'User',
-        role: 'freelancer', // Default role
+        role: 'freelancer',
         permissions: [],
         createdAt: new Date(),
         onboardingCompleted: false,
         onboardingStep: 1,
       };
-      setCurrentUser(customUser);
-    });
+      await setDoc(userRef, {
+        email: customUser.email,
+        name: customUser.name,
+        role: customUser.role,
+        permissions: customUser.permissions,
+        createdAt: serverTimestamp(),
+        onboardingCompleted: false,
+        onboardingStep: 1,
+      });
+    }
+    setCurrentUser(customUser);
+    return customUser;
   }
 
   function logout() {
@@ -74,37 +109,66 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     });
   }
 
-  function updateUserRole(role: UserRole) {
+  async function updateUserRole(role: UserRole) {
     if (currentUser) {
+      const userRef = doc(db, 'users', currentUser.id);
+      await updateDoc(userRef, { role });
       setCurrentUser({ ...currentUser, role });
     }
   }
 
-  function completeOnboarding() {
+  async function completeOnboarding() {
     if (currentUser) {
-      setCurrentUser({ 
-        ...currentUser, 
+      const userRef = doc(db, 'users', currentUser.id);
+      await updateDoc(userRef, { onboardingCompleted: true, onboardingStep: 5 });
+      setCurrentUser({
+        ...currentUser,
         onboardingCompleted: true,
-        onboardingStep: 5
+        onboardingStep: 5,
       });
     }
   }
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (firebaseUser: FirebaseUser | null) => {
+    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser: FirebaseUser | null) => {
       if (firebaseUser) {
-        // Create custom user object from Firebase user
-        const customUser: User = {
-          id: firebaseUser.uid,
-          email: firebaseUser.email || '',
-          name: firebaseUser.displayName || 'User',
-          role: 'freelancer', // Default role - in real app, fetch from Firestore
-          permissions: [],
-          createdAt: new Date(),
-          onboardingCompleted: false,
-          onboardingStep: 1,
-        };
-        setCurrentUser(customUser);
+        const userRef = doc(db, 'users', firebaseUser.uid);
+        const snapshot = await getDoc(userRef);
+        if (snapshot.exists()) {
+          const data = snapshot.data();
+          const customUser: User = {
+            id: firebaseUser.uid,
+            email: data.email || '',
+            name: data.name || firebaseUser.displayName || 'User',
+            role: data.role || 'freelancer',
+            permissions: data.permissions || [],
+            createdAt: data.createdAt?.toDate?.() || new Date(),
+            onboardingCompleted: data.onboardingCompleted || false,
+            onboardingStep: data.onboardingStep || 1,
+          };
+          setCurrentUser(customUser);
+        } else {
+          const customUser: User = {
+            id: firebaseUser.uid,
+            email: firebaseUser.email || '',
+            name: firebaseUser.displayName || 'User',
+            role: 'freelancer',
+            permissions: [],
+            createdAt: new Date(),
+            onboardingCompleted: false,
+            onboardingStep: 1,
+          };
+          await setDoc(userRef, {
+            email: customUser.email,
+            name: customUser.name,
+            role: customUser.role,
+            permissions: customUser.permissions,
+            createdAt: serverTimestamp(),
+            onboardingCompleted: false,
+            onboardingStep: 1,
+          });
+          setCurrentUser(customUser);
+        }
       } else {
         setCurrentUser(null);
       }
@@ -121,7 +185,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     logout,
     loading,
     updateUserRole,
-    completeOnboarding
+    completeOnboarding,
   };
 
   return (

--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -11,15 +11,16 @@ import {
   Trash2
 } from 'lucide-react';
 import toast from 'react-hot-toast';
-import { 
-  getClients, 
-  addClient, 
-  updateClient, 
-  deleteClient, 
+import {
+  getClients,
+  addClient,
+  updateClient,
+  deleteClient,
   updateClientStatus,
-  type Client, 
-  type ClientFormData 
+  type Client,
+  type ClientFormData
 } from '../firebase/clients';
+import { useAuth } from '../contexts/AuthContext';
 
 function Clients() {
   const [clients, setClients] = useState<Client[]>([]);
@@ -28,6 +29,7 @@ function Clients() {
   const [editingClient, setEditingClient] = useState<Client | null>(null);
   const [loading, setLoading] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const { currentUser } = useAuth();
 
   const {
     register,
@@ -38,9 +40,10 @@ function Clients() {
 
   useEffect(() => {
     const fetchClients = async () => {
+      if (!currentUser) return;
       try {
         setIsLoading(true);
-        const fetchedClients = await getClients();
+        const fetchedClients = await getClients(currentUser.id);
         setClients(fetchedClients);
       } catch (error) {
         console.error('Error fetching clients:', error);
@@ -51,7 +54,7 @@ function Clients() {
     };
 
     fetchClients();
-  }, []);
+  }, [currentUser]);
 
   const onSubmit = async (data: ClientFormData) => {
     try {
@@ -68,7 +71,8 @@ function Clients() {
         toast.success('Client updated successfully!');
       } else {
         // Add new client
-        const newClient = await addClient(data);
+        if (!currentUser) throw new Error('Not authenticated');
+        const newClient = await addClient(data, currentUser.id);
         setClients([newClient, ...clients]);
         toast.success('Client added successfully!');
       }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -25,13 +25,14 @@ function Login() {
   const onSubmit = async (data: LoginForm) => {
     try {
       setLoading(true);
-      await login(data.email, data.password);
+      const user = await login(data.email, data.password);
       toast.success('Successfully logged in!');
-      
-      // Check if user needs onboarding
-      // In a real app, you'd check the user's onboarding status from Firebase
-      // For now, we'll redirect to onboarding for new users
-      navigate('/onboarding');
+
+      if (user.onboardingCompleted) {
+        navigate('/dashboard');
+      } else {
+        navigate('/onboarding');
+      }
     } catch (error: any) {
       toast.error(error.message || 'Failed to log in');
     } finally {

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -34,7 +34,7 @@ function Signup() {
       console.log('Attempting to create account with:', data.email);
       await signup(data.email, data.password, data.name);
       toast.success('Account created successfully!');
-      navigate('/dashboard');
+      navigate('/onboarding');
     } catch (error: any) {
       console.error('Signup error:', error);
       console.error('Error code:', error.code);


### PR DESCRIPTION
## Summary
- add Firestore security rules enforcing role-based access and onboarding completion
- persist user profiles and onboarding state in Firestore during signup, login, and onboarding
- scope client data to authenticated user with `ownerId` filtering

## Testing
- `npm run lint` *(fails: File is already defined as a built-in global variable and other existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fdde4ca5c832a8e99a9763f9616ec