### PR TITLE
Add project dashboard and task views

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ import Layout from './components/Layout';
 import Onboarding from './components/Onboarding';
 import ProjectRequest from './components/ProjectRequest';
 import ProjectRequestManagement from './components/ProjectRequestManagement';
+import ProjectDashboard from './pages/ProjectDashboard';
+import Tasks from './pages/Tasks';
 
 function App() {
   const { currentUser } = useAuth();
@@ -76,6 +78,8 @@ function App() {
             <Route path="employees" element={<Employees />} />
             <Route path="invoices" element={<Invoices />} />
             <Route path="projects" element={<Projects />} />
+            <Route path="projects/:projectId" element={<ProjectDashboard />} />
+            <Route path="tasks" element={<Tasks />} />
             <Route path="files" element={<Files />} />
             <Route path="analytics" element={<Analytics />} />
             <Route path="settings" element={<Settings />} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,11 +4,12 @@ import {
   Users, 
   FileText, 
   FolderOpen, 
-  Upload, 
+  Upload,
   BarChart3,
   Settings as SettingsIcon,
   LogOut,
-  Briefcase
+  Briefcase,
+  CheckSquare
 } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -43,6 +44,7 @@ function Sidebar() {
         { name: 'Dashboard', href: '/dashboard', icon: Home },
         { name: 'Invoices', href: '/invoices', icon: FileText },
         { name: 'Projects', href: '/projects', icon: FolderOpen },
+        { name: 'My Tasks', href: '/tasks', icon: CheckSquare },
         { name: 'Files', href: '/files', icon: Upload },
         { name: 'Analytics', href: '/analytics', icon: BarChart3 },
         { name: 'Settings', href: '/settings', icon: SettingsIcon },

--- a/src/data/mockTasks.ts
+++ b/src/data/mockTasks.ts
@@ -1,0 +1,35 @@
+export interface Task {
+  id: string;
+  projectId: string;
+  title: string;
+  assignee: string;
+  status: 'todo' | 'in-progress' | 'review' | 'done';
+  dueDate: string;
+}
+
+export const mockTasks: Task[] = [
+  {
+    id: 't1',
+    projectId: '1',
+    title: 'Design homepage layout',
+    assignee: 'Designer',
+    status: 'in-progress',
+    dueDate: '2024-02-10',
+  },
+  {
+    id: 't2',
+    projectId: '1',
+    title: 'Implement responsive header',
+    assignee: 'Developer',
+    status: 'todo',
+    dueDate: '2024-02-12',
+  },
+  {
+    id: 't3',
+    projectId: '2',
+    title: 'Create mobile wireframes',
+    assignee: 'Product Manager',
+    status: 'review',
+    dueDate: '2024-02-20',
+  },
+];

--- a/src/pages/ProjectDashboard.tsx
+++ b/src/pages/ProjectDashboard.tsx
@@ -1,0 +1,59 @@
+import { useParams } from 'react-router-dom';
+import { mockTasks, Task } from '../data/mockTasks';
+
+function ProjectDashboard() {
+  const { projectId } = useParams();
+  const projectTasks: Task[] = mockTasks.filter(t => t.projectId === projectId);
+  const teamMembers = Array.from(new Set(projectTasks.map(t => t.assignee)));
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900">Project Dashboard</h1>
+      <div className="card space-y-4">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900">Team Members</h2>
+          {teamMembers.length ? (
+            <ul className="list-disc pl-5 mt-2 space-y-1">
+              {teamMembers.map(member => (
+                <li key={member} className="text-gray-700">{member}</li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-gray-600">No team members assigned.</p>
+          )}
+        </div>
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">Tasks</h2>
+          {projectTasks.length ? (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Task</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Assignee</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Due Date</th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {projectTasks.map(task => (
+                    <tr key={task.id} className="hover:bg-gray-50">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{task.title}</td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{task.assignee}</td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 capitalize">{task.status.replace('-', ' ')}</td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{task.dueDate}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="text-gray-600">No tasks for this project.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ProjectDashboard;

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 import { 
   Plus, 
   Search, 
@@ -43,6 +44,7 @@ function Projects() {
   const [showForm, setShowForm] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const [editingProject, setEditingProject] = useState<Project | null>(null);
+  const navigate = useNavigate();
 
   const {
     register,
@@ -312,7 +314,11 @@ function Projects() {
       {/* Projects Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {filteredProjects.map((project) => (
-          <div key={project.id} className="card hover:shadow-md transition-shadow">
+          <div
+            key={project.id}
+            className="card hover:shadow-md transition-shadow cursor-pointer"
+            onClick={() => navigate(`/projects/${project.id}`)}
+          >
             <div className="flex justify-between items-start mb-4">
               <div>
                 <h3 className="text-lg font-medium text-gray-900">{project.name}</h3>
@@ -359,9 +365,9 @@ function Projects() {
             </div>
             
             <div className="flex justify-between items-center mt-4 pt-4 border-t border-gray-200">
-              <div className="flex space-x-2">
+              <div className="flex space-x-2" onClick={(e) => e.stopPropagation()}>
                 <button
-                  onClick={() => window.open(`/project/${project.id}`, '_blank')}
+                  onClick={() => navigate(`/projects/${project.id}`)}
                   className="text-blue-600 hover:text-blue-900"
                 >
                   <Eye className="h-4 w-4" />

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -1,0 +1,43 @@
+import { useAuth } from '../contexts/AuthContext';
+import { mockTasks, Task } from '../data/mockTasks';
+
+function Tasks() {
+  const { currentUser } = useAuth();
+  const userTasks: Task[] = mockTasks.filter(t => t.assignee === currentUser?.name);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900">My Tasks</h1>
+      <div className="card">
+        {userTasks.length ? (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Task</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Project</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Due Date</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {userTasks.map(task => (
+                  <tr key={task.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{task.title}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{task.projectId}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 capitalize">{task.status.replace('-', ' ')}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{task.dueDate}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="text-gray-600">No tasks assigned.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default Tasks;


### PR DESCRIPTION
## Summary
- add project dashboard page showing team members and tasks
- add employee My Tasks page with assigned tasks list
- link new pages via navigation and routing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ff8033ce4832a905a91580db1c3f4