### PR TITLE
feat: manage project requests via firestore

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -39,6 +39,15 @@ service cloud.firestore {
       allow write: if isSignedIn() && onboardingComplete() && (hasRole('admin') || hasRole('freelancer') || hasRole('team_member'));
     }
 
+    match /projectRequests/{requestId} {
+      allow create: if isSignedIn() && onboardingComplete() && hasRole('client');
+      allow read: if isSignedIn() && onboardingComplete() &&
+        (hasRole('admin') || hasRole('freelancer') || resource.data.clientId == request.auth.uid);
+      allow update: if isSignedIn() && onboardingComplete() && (hasRole('admin') || hasRole('freelancer'));
+      allow delete: if isSignedIn() && onboardingComplete() &&
+        (hasRole('admin') || resource.data.clientId == request.auth.uid);
+    }
+
     match /{document=**} {
       allow read, write: if false;
     }

--- a/src/components/ProjectRequest.tsx
+++ b/src/components/ProjectRequest.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import toast from 'react-hot-toast';
+import { addProjectRequest } from '../firebase/projectRequests';
 
 interface ProjectRequestForm {
   projectName: string;
@@ -67,20 +68,14 @@ function ProjectRequest() {
 
   const onSubmit = async (data: ProjectRequestForm) => {
     try {
-      const projectRequest = {
+      await addProjectRequest({
         ...data,
         skills: selectedSkills,
-        clientId: currentUser?.id,
-        clientName: currentUser?.name,
-        clientEmail: currentUser?.email,
-        status: 'pending',
-        createdAt: new Date(),
-        id: Date.now().toString(),
-      };
+        clientId: currentUser?.id || '',
+        clientName: currentUser?.name || '',
+        clientEmail: currentUser?.email || '',
+      });
 
-      // In a real app, you'd save this to Firebase
-      console.log('Project Request:', projectRequest);
-      
       toast.success('Project request submitted successfully!');
       setShowForm(false);
       reset();

--- a/src/components/ProjectRequestManagement.tsx
+++ b/src/components/ProjectRequestManagement.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
-import { 
-  Eye, 
-  CheckCircle, 
-  XCircle, 
-  Clock, 
+import {
+  Eye,
+  CheckCircle,
+  XCircle,
+  Clock,
   Calendar,
   DollarSign,
   Briefcase,
@@ -11,22 +11,11 @@ import {
   Filter
 } from 'lucide-react';
 import toast from 'react-hot-toast';
-
-interface ProjectRequest {
-  id: string;
-  projectName: string;
-  description: string;
-  budget: string;
-  timeline: string;
-  category: string;
-  skills: string[];
-  additionalRequirements: string;
-  clientId: string;
-  clientName: string;
-  clientEmail: string;
-  status: 'pending' | 'approved' | 'rejected' | 'in-progress';
-  createdAt: Date;
-}
+import {
+  getProjectRequests,
+  updateRequestStatus,
+  ProjectRequest
+} from '../firebase/projectRequests';
 
 function ProjectRequestManagement() {
   const [projectRequests, setProjectRequests] = useState<ProjectRequest[]>([]);
@@ -36,65 +25,31 @@ function ProjectRequestManagement() {
   const [statusFilter, setStatusFilter] = useState<string>('all');
 
   useEffect(() => {
-    // Mock data - in real app, fetch from Firebase
-    setProjectRequests([
-      {
-        id: '1',
-        projectName: 'E-commerce Website Redesign',
-        description: 'Need a modern e-commerce website with payment integration and inventory management.',
-        budget: '$5,000 - $10,000',
-        timeline: '2-3 months',
-        category: 'Website Development',
-        skills: ['Web Development', 'UI/UX Design', 'E-commerce'],
-        additionalRequirements: 'Must be mobile responsive and SEO optimized',
-        clientId: 'client1',
-        clientName: 'John Smith',
-        clientEmail: 'john@example.com',
-        status: 'pending',
-        createdAt: new Date('2024-01-15'),
-      },
-      {
-        id: '2',
-        projectName: 'Mobile App for Food Delivery',
-        description: 'iOS and Android app for food delivery service with real-time tracking.',
-        budget: '$25,000 - $50,000',
-        timeline: '3-6 months',
-        category: 'Mobile App',
-        skills: ['Mobile Development', 'UI/UX Design', 'Backend Development'],
-        additionalRequirements: 'Integration with payment gateways and maps API',
-        clientId: 'client2',
-        clientName: 'Sarah Johnson',
-        clientEmail: 'sarah@example.com',
-        status: 'approved',
-        createdAt: new Date('2024-01-10'),
-      },
-      {
-        id: '3',
-        projectName: 'Brand Identity Design',
-        description: 'Complete brand identity including logo, color palette, and brand guidelines.',
-        budget: '$1,000 - $5,000',
-        timeline: '1 month',
-        category: 'Design & Branding',
-        skills: ['Graphic Design', 'Branding'],
-        additionalRequirements: 'Modern and minimalist design approach',
-        clientId: 'client3',
-        clientName: 'Mike Wilson',
-        clientEmail: 'mike@example.com',
-        status: 'in-progress',
-        createdAt: new Date('2024-01-08'),
-      },
-    ]);
+    const fetchRequests = async () => {
+      const requests = await getProjectRequests();
+      setProjectRequests(requests);
+    };
+
+    fetchRequests();
   }, []);
 
-  const handleStatusUpdate = (requestId: string, newStatus: ProjectRequest['status']) => {
-    setProjectRequests(prev => 
-      prev.map(request => 
-        request.id === requestId 
-          ? { ...request, status: newStatus }
-          : request
-      )
-    );
-    toast.success(`Project request ${newStatus}`);
+  const handleStatusUpdate = async (
+    requestId: string,
+    newStatus: ProjectRequest['status']
+  ) => {
+    try {
+      await updateRequestStatus(requestId, newStatus);
+      setProjectRequests(prev =>
+        prev.map(request =>
+          request.id === requestId
+            ? { ...request, status: newStatus }
+            : request
+        )
+      );
+      toast.success(`Project request ${newStatus}`);
+    } catch (error) {
+      toast.error('Failed to update request status');
+    }
   };
 
   const getStatusColor = (status: string) => {
@@ -278,7 +233,7 @@ function ProjectRequestManagement() {
                   <div className="space-y-1 text-sm">
                     <p><strong>Name:</strong> {selectedRequest.clientName}</p>
                     <p><strong>Email:</strong> {selectedRequest.clientEmail}</p>
-                    <p><strong>Submitted:</strong> {selectedRequest.createdAt.toLocaleDateString()}</p>
+                    <p><strong>Submitted:</strong> {new Date(selectedRequest.createdAt).toLocaleDateString()}</p>
                   </div>
                 </div>
 

--- a/src/firebase/projectRequests.ts
+++ b/src/firebase/projectRequests.ts
@@ -1,0 +1,127 @@
+import {
+  collection,
+  addDoc,
+  getDocs,
+  updateDoc,
+  deleteDoc,
+  doc,
+  query,
+  orderBy,
+  serverTimestamp,
+  DocumentData,
+  QueryDocumentSnapshot
+} from 'firebase/firestore';
+import { db } from './config';
+
+export interface ProjectRequest {
+  id: string;
+  projectName: string;
+  description: string;
+  budget: string;
+  timeline: string;
+  category: string;
+  skills: string[];
+  additionalRequirements: string;
+  clientId: string;
+  clientName: string;
+  clientEmail: string;
+  status: 'pending' | 'approved' | 'rejected' | 'in-progress';
+  createdAt: string;
+}
+
+export interface ProjectRequestInput {
+  projectName: string;
+  description: string;
+  budget: string;
+  timeline: string;
+  category: string;
+  skills: string[];
+  additionalRequirements: string;
+  clientId: string;
+  clientName: string;
+  clientEmail: string;
+}
+
+const docToProjectRequest = (docSnap: QueryDocumentSnapshot<DocumentData>): ProjectRequest => {
+  const data = docSnap.data();
+  return {
+    id: docSnap.id,
+    projectName: data.projectName || '',
+    description: data.description || '',
+    budget: data.budget || '',
+    timeline: data.timeline || '',
+    category: data.category || '',
+    skills: data.skills || [],
+    additionalRequirements: data.additionalRequirements || '',
+    clientId: data.clientId || '',
+    clientName: data.clientName || '',
+    clientEmail: data.clientEmail || '',
+    status: data.status || 'pending',
+    createdAt:
+      data.createdAt?.toDate?.()?.toISOString()?.split('T')[0] ||
+      new Date().toISOString().split('T')[0],
+  };
+};
+
+export const addProjectRequest = async (
+  request: ProjectRequestInput
+): Promise<ProjectRequest> => {
+  try {
+    const requestsRef = collection(db, 'projectRequests');
+    const docRef = await addDoc(requestsRef, {
+      ...request,
+      status: 'pending',
+      createdAt: serverTimestamp(),
+    });
+
+    return {
+      id: docRef.id,
+      ...request,
+      status: 'pending',
+      createdAt: new Date().toISOString().split('T')[0],
+    };
+  } catch (error) {
+    console.error('Error adding project request:', error);
+    throw new Error('Failed to add project request');
+  }
+};
+
+export const getProjectRequests = async (): Promise<ProjectRequest[]> => {
+  try {
+    const requestsRef = collection(db, 'projectRequests');
+    const q = query(requestsRef, orderBy('createdAt', 'desc'));
+    const querySnapshot = await getDocs(q);
+
+    return querySnapshot.docs.map(docToProjectRequest);
+  } catch (error) {
+    console.error('Error fetching project requests:', error);
+    return [];
+  }
+};
+
+export const updateRequestStatus = async (
+  requestId: string,
+  status: ProjectRequest['status']
+): Promise<void> => {
+  try {
+    const requestRef = doc(db, 'projectRequests', requestId);
+    await updateDoc(requestRef, {
+      status,
+      updatedAt: serverTimestamp(),
+    });
+  } catch (error) {
+    console.error('Error updating request status:', error);
+    throw new Error('Failed to update request status');
+  }
+};
+
+export const deleteProjectRequest = async (requestId: string): Promise<void> => {
+  try {
+    const requestRef = doc(db, 'projectRequests', requestId);
+    await deleteDoc(requestRef);
+  } catch (error) {
+    console.error('Error deleting project request:', error);
+    throw new Error('Failed to delete project request');
+  }
+};
+


### PR DESCRIPTION
## Summary
- add Firestore helpers for project requests: create, list, update, delete
- persist requests from ProjectRequest component
- fetch and manage project requests with Firestore in management view
- enforce security rules for projectRequests collection

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ffa82af74832a98aab4161bc365bf