### PR TITLE
feat: implement invoice utilities and Stripe payments

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -30,7 +30,11 @@ service cloud.firestore {
     }
 
     match /invoices/{invoiceId} {
-      allow read: if isSignedIn() && onboardingComplete();
+      allow read: if isSignedIn() && onboardingComplete() && (
+        hasRole('admin') ||
+        hasRole('freelancer') ||
+        (hasRole('client') && resource.data.clientId == request.auth.uid)
+      );
       allow create, update, delete: if isSignedIn() && onboardingComplete() && (hasRole('admin') || hasRole('freelancer'));
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@stripe/react-stripe-js": "^2.5.1",
+        "@stripe/stripe-js": "^2.1.1",
         "clsx": "^2.0.0",
         "date-fns": "^2.30.0",
         "firebase": "^10.14.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test": "echo \"No tests\" && exit 0"
   },
   "dependencies": {
+    "@stripe/react-stripe-js": "^2.5.1",
+    "@stripe/stripe-js": "^2.1.1",
     "clsx": "^2.0.0",
     "date-fns": "^2.30.0",
     "firebase": "^10.14.1",

--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -1,6 +1,19 @@
 import { useState, FormEvent } from 'react';
-import { X, CreditCard, Lock, CheckCircle } from 'lucide-react';
+import { X } from 'lucide-react';
+import {
+  loadStripe,
+  StripeCardElementOptions,
+} from '@stripe/stripe-js';
+import {
+  Elements,
+  CardElement,
+  useStripe,
+  useElements,
+} from '@stripe/react-stripe-js';
 import { Payment } from '../types/payments';
+import { updateInvoiceStatus } from '../firebase/invoices';
+
+const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY || '');
 
 interface PaymentModalProps {
   isOpen: boolean;
@@ -11,162 +24,131 @@ interface PaymentModalProps {
   invoiceId: string;
 }
 
-function PaymentModal({ isOpen, onClose, onComplete, amount, invoiceId }: PaymentModalProps) {
-  const [step, setStep] = useState<'form' | 'processing' | 'success'>('form');
-  const [formData, setFormData] = useState({
-    cardNumber: '',
-    expiryDate: '',
-    cvv: '',
-    name: '',
-  });
+const cardElementOptions: StripeCardElementOptions = {
+  style: {
+    base: {
+      fontSize: '16px',
+      color: '#32325d',
+      '::placeholder': {
+        color: '#a0aec0',
+      },
+    },
+    invalid: {
+      color: '#e53e3e',
+    },
+  },
+};
+
+/* eslint-disable no-unused-vars */
+type CheckoutFormProps = {
+  amount: number;
+  invoiceId: string;
+  onComplete: (payment: Payment) => void;
+  onClose: () => void;
+};
+/* eslint-enable no-unused-vars */
+
+function CheckoutForm({ amount, invoiceId, onComplete, onClose }: CheckoutFormProps) {
+  const stripe = useStripe();
+  const elements = useElements();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    setStep('processing');
+    if (!stripe || !elements) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/create-payment-intent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount }),
+      });
+      const { clientSecret } = await res.json();
+      const result = await stripe.confirmCardPayment(clientSecret, {
+        payment_method: {
+          card: elements.getElement(CardElement)!,
+        },
+      });
 
-    // Simulate payment processing
-    setTimeout(() => {
-      const payment: Payment = {
-        id: Date.now().toString(),
-        invoiceId,
-        amount,
-        currency: 'USD',
-        status: 'completed',
-        method: 'credit_card',
-        transactionId: `txn_${Date.now()}`,
-        paidAt: new Date(),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
-
-      setStep('success');
-      
-      setTimeout(() => {
+      if (result.error) {
+        setError(result.error.message || 'Payment failed');
+      } else if (result.paymentIntent && result.paymentIntent.status === 'succeeded') {
+        await updateInvoiceStatus(invoiceId, 'paid');
+        const payment: Payment = {
+          id: result.paymentIntent.id,
+          invoiceId,
+          amount,
+          currency: result.paymentIntent.currency || 'usd',
+          status: 'completed',
+          method: 'stripe',
+          transactionId: result.paymentIntent.id,
+          paidAt: new Date(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
         onComplete(payment);
         onClose();
-        setStep('form');
-        setFormData({ cardNumber: '', expiryDate: '', cvv: '', name: '' });
-      }, 2000);
-    }, 3000);
+      }
+    } catch (err) {
+      console.error('Payment error', err);
+      setError('Payment failed');
+    } finally {
+      setLoading(false);
+    }
   };
 
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Amount to Pay
+        </label>
+        <div className="text-2xl font-bold text-gray-900">
+          ${amount.toFixed(2)}
+        </div>
+      </div>
+      <CardElement options={cardElementOptions} className="p-3 border rounded" />
+      {error && <div className="text-sm text-red-600">{error}</div>}
+      <button
+        type="submit"
+        className="btn-primary w-full"
+        disabled={!stripe || loading}
+      >
+        {loading ? 'Processing...' : `Pay $${amount.toFixed(2)}`}
+      </button>
+    </form>
+  );
+}
+
+function PaymentModal({ isOpen, onClose, onComplete, amount, invoiceId }: PaymentModalProps) {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
-        <div className="flex justify-between items-center p-6 border-b border-gray-200">
-          <h2 className="text-xl font-semibold text-gray-900">Payment</h2>
-          <button
-            onClick={onClose}
-            className="text-gray-400 hover:text-gray-600"
-          >
-            <X className="h-6 w-6" />
-          </button>
-        </div>
-
-        <div className="p-6">
-          {step === 'form' && (
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Amount to Pay
-                </label>
-                <div className="text-2xl font-bold text-gray-900">
-                  ${amount.toFixed(2)}
-                </div>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Card Number
-                </label>
-                <div className="relative">
-                  <CreditCard className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-                  <input
-                    type="text"
-                    placeholder="1234 5678 9012 3456"
-                    value={formData.cardNumber}
-                    onChange={(e) => setFormData({ ...formData, cardNumber: e.target.value })}
-                    className="input-field pl-10"
-                    required
-                  />
-                </div>
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Expiry Date
-                  </label>
-                  <input
-                    type="text"
-                    placeholder="MM/YY"
-                    value={formData.expiryDate}
-                    onChange={(e) => setFormData({ ...formData, expiryDate: e.target.value })}
-                    className="input-field"
-                    required
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    CVV
-                  </label>
-                  <div className="relative">
-                    <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-                    <input
-                      type="text"
-                      placeholder="123"
-                      value={formData.cvv}
-                      onChange={(e) => setFormData({ ...formData, cvv: e.target.value })}
-                      className="input-field pl-10"
-                      required
-                    />
-                  </div>
-                </div>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Cardholder Name
-                </label>
-                <input
-                  type="text"
-                  placeholder="John Doe"
-                  value={formData.name}
-                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  className="input-field"
-                  required
-                />
-              </div>
-
-              <button
-                type="submit"
-                className="btn-primary w-full"
-              >
-                Pay ${amount.toFixed(2)}
-              </button>
-            </form>
-          )}
-
-          {step === 'processing' && (
-            <div className="text-center py-8">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600 mx-auto mb-4"></div>
-              <h3 className="text-lg font-medium text-gray-900 mb-2">Processing Payment</h3>
-              <p className="text-gray-600">Please wait while we process your payment...</p>
-            </div>
-          )}
-
-          {step === 'success' && (
-            <div className="text-center py-8">
-              <CheckCircle className="h-12 w-12 text-green-500 mx-auto mb-4" />
-              <h3 className="text-lg font-medium text-gray-900 mb-2">Payment Successful!</h3>
-              <p className="text-gray-600">Your payment has been processed successfully.</p>
-            </div>
-          )}
+    <Elements stripe={stripePromise}>
+      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+        <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
+          <div className="flex justify-between items-center p-6 border-b border-gray-200">
+            <h2 className="text-xl font-semibold text-gray-900">Payment</h2>
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600"
+            >
+              <X className="h-6 w-6" />
+            </button>
+          </div>
+          <div className="p-6">
+            <CheckoutForm
+              amount={amount}
+              invoiceId={invoiceId}
+              onComplete={onComplete}
+              onClose={onClose}
+            />
+          </div>
         </div>
       </div>
-    </div>
+    </Elements>
   );
 }
 

--- a/src/firebase/invoices.ts
+++ b/src/firebase/invoices.ts
@@ -1,0 +1,124 @@
+import {
+  collection,
+  doc,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  getDocs,
+  query,
+  orderBy,
+  where,
+  serverTimestamp,
+  DocumentData,
+  QueryDocumentSnapshot,
+} from 'firebase/firestore';
+import { db } from './config';
+
+export interface Invoice {
+  id: string;
+  clientId: string;
+  clientName: string;
+  amount: number;
+  status: 'pending' | 'paid' | 'overdue';
+  dueDate: string;
+  invoiceNumber: string;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+export interface InvoiceInput {
+  clientId: string;
+  clientName: string;
+  amount: number;
+  dueDate: string;
+  invoiceNumber: string;
+  status?: Invoice['status'];
+}
+
+const docToInvoice = (
+  docSnap: QueryDocumentSnapshot<DocumentData>
+): Invoice => {
+  const data = docSnap.data();
+  return {
+    id: docSnap.id,
+    clientId: data.clientId || '',
+    clientName: data.clientName || '',
+    amount: data.amount || 0,
+    status: data.status || 'pending',
+    dueDate: data.dueDate || '',
+    invoiceNumber: data.invoiceNumber || '',
+    createdAt:
+      data.createdAt?.toDate?.()?.toISOString()?.split('T')[0] ||
+      new Date().toISOString().split('T')[0],
+    updatedAt: data.updatedAt?.toDate?.()?.toISOString()?.split('T')[0],
+  };
+};
+
+export const getInvoices = async (
+  userId?: string,
+  role?: string
+): Promise<Invoice[]> => {
+  try {
+    const invoicesRef = collection(db, 'invoices');
+    const q =
+      role === 'client' && userId
+        ? query(
+            invoicesRef,
+            where('clientId', '==', userId),
+            orderBy('createdAt', 'desc')
+          )
+        : query(invoicesRef, orderBy('createdAt', 'desc'));
+    const snapshot = await getDocs(q);
+    return snapshot.docs.map(docToInvoice);
+  } catch (error) {
+    console.error('Error fetching invoices:', error);
+    return [];
+  }
+};
+
+export const addInvoice = async (
+  invoice: InvoiceInput
+): Promise<Invoice> => {
+  try {
+    const invoicesRef = collection(db, 'invoices');
+    const docRef = await addDoc(invoicesRef, {
+      ...invoice,
+      status: invoice.status || 'pending',
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    });
+    return {
+      id: docRef.id,
+      ...invoice,
+      status: invoice.status || 'pending',
+      createdAt: new Date().toISOString().split('T')[0],
+    };
+  } catch (error) {
+    console.error('Error adding invoice:', error);
+    throw new Error('Failed to add invoice');
+  }
+};
+
+export const updateInvoiceStatus = async (
+  invoiceId: string,
+  status: Invoice['status']
+): Promise<void> => {
+  try {
+    const invoiceRef = doc(db, 'invoices', invoiceId);
+    await updateDoc(invoiceRef, { status, updatedAt: serverTimestamp() });
+  } catch (error) {
+    console.error('Error updating invoice status:', error);
+    throw new Error('Failed to update invoice status');
+  }
+};
+
+export const deleteInvoice = async (invoiceId: string): Promise<void> => {
+  try {
+    const invoiceRef = doc(db, 'invoices', invoiceId);
+    await deleteDoc(invoiceRef);
+  } catch (error) {
+    console.error('Error deleting invoice:', error);
+    throw new Error('Failed to delete invoice');
+  }
+};
+


### PR DESCRIPTION
## Summary
- add Firestore helpers for invoices
- load invoices from Firestore and enable creation
- integrate Stripe checkout and mark invoices paid
- restrict invoice reads by user role

## Testing
- `npm test`
- `npm run lint` *(fails: 3 warnings, no errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ffeb506ac832a8738677d9645fdc4