### PR TITLE
Implement client portal data display and access control

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -25,7 +25,9 @@ service cloud.firestore {
     }
 
     match /projects/{projectId} {
-      allow read: if isSignedIn() && onboardingComplete();
+      allow read: if isSignedIn() && onboardingComplete() && (
+        hasRole('admin') || hasRole('freelancer') || resource.data.clientId == request.auth.uid
+      );
       allow create, update, delete: if isSignedIn() && onboardingComplete() && !hasRole('client');
     }
 
@@ -39,7 +41,9 @@ service cloud.firestore {
     }
 
     match /files/{fileId} {
-      allow read: if isSignedIn() && onboardingComplete();
+      allow read: if isSignedIn() && onboardingComplete() && (
+        hasRole('admin') || hasRole('freelancer') || resource.data.clientId == request.auth.uid
+      );
       allow write: if isSignedIn() && onboardingComplete() && (hasRole('admin') || hasRole('freelancer') || hasRole('team_member'));
     }
 


### PR DESCRIPTION
## Summary
- fetch invoices, projects, and files by client and display in client portal
- restrict project and file reads so clients only access their own data
- add client-aware project and file helpers

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a00172f130832aa19b824d87c9b761