### PR TITLE
fix: correct stripe import in payment modal

### DIFF
--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -1,9 +1,7 @@
 import { useState, FormEvent } from 'react';
 import { X } from 'lucide-react';
-import {
-  loadStripe,
-  StripeCardElementOptions,
-} from '@stripe/stripe-js';
+import { loadStripe } from '@stripe/stripe-js';
+import type { StripeCardElementOptions } from '@stripe/stripe-js';
 import {
   Elements,
   CardElement,


### PR DESCRIPTION
## Summary
- import stripe helpers correctly from `@stripe/stripe-js` and treat `StripeCardElementOptions` as a type

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a012bfbc64832a984fc6f2adbfc42a