### PR TITLE
refactor freelancer flow to employer/employee

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Shifter - Client Portal for Freelancers
+# Shifter - Employer-Employee Portal
 
-A modern, professional client portal application that helps freelancers manage their client relationships, invoices, projects, and file sharing in one beautiful interface.
+A modern, professional portal application that helps employers manage their employee relationships, invoices, projects, and file sharing in one interface.
 
 ## 🚀 Features
 
@@ -13,7 +13,7 @@ A modern, professional client portal application that helps freelancers manage t
 ### 👥 Role-Based Access Control
 - **Client Access**: Submit project requests, track progress, manage invoices
 - **Admin Access**: Manage all projects, clients, and platform settings
-- **Freelancer Access**: Manage clients, projects, and invoices (default)
+- **Employer Access**: Manage employees, projects, and invoices (default)
 
 ### 📋 Project Management
 - **Project Requests**: Clients can submit detailed project requests
@@ -31,7 +31,7 @@ A modern, professional client portal application that helps freelancers manage t
 - **Project Analytics**: Track project performance
 - **Financial Reports**: Revenue and payment analytics
 
-### For Freelancers
+### For Employers
 - **Dashboard**: Overview of clients, invoices, revenue, and recent activity
 - **Client Management**: Add, edit, and manage client information with unique portal URLs
 - **Invoice Management**: Create, track, and manage invoices with status tracking
@@ -148,7 +148,7 @@ VITE_FIREBASE_APP_ID=your-app-id
 4. **Analytics**: Access comprehensive business analytics
 5. **Settings**: Configure platform settings and permissions
 
-### For Freelancers
+### For Employers
 
 1. **Add Clients**: Go to Clients page and add your client information
 2. **Create Invoices**: Generate professional invoices for your clients
@@ -194,7 +194,7 @@ npm run build
 ## 💰 Revenue Model
 
 The application is designed with a $5/month per client portal revenue model:
-- Freelancers pay $5/month for each active client portal
+- Employers pay $5/month for each active employee portal
 - Clients get free access to their dedicated portal
 - Scalable pricing based on number of clients
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -19,14 +19,14 @@ service cloud.firestore {
     }
 
     match /clients/{clientId} {
-      allow create: if isSignedIn() && onboardingComplete() && (hasRole('admin') || hasRole('freelancer')) && request.resource.data.ownerId == request.auth.uid;
+      allow create: if isSignedIn() && onboardingComplete() && (hasRole('admin') || hasRole('employer')) && request.resource.data.ownerId == request.auth.uid;
       allow read: if isSignedIn() && onboardingComplete() && resource.data.ownerId == request.auth.uid;
-      allow update, delete: if isSignedIn() && onboardingComplete() && resource.data.ownerId == request.auth.uid && (hasRole('admin') || hasRole('freelancer'));
+      allow update, delete: if isSignedIn() && onboardingComplete() && resource.data.ownerId == request.auth.uid && (hasRole('admin') || hasRole('employer'));
     }
 
     match /projects/{projectId} {
       allow read: if isSignedIn() && onboardingComplete() && (
-        hasRole('admin') || hasRole('freelancer') || resource.data.clientId == request.auth.uid
+        hasRole('admin') || hasRole('employer') || resource.data.clientId == request.auth.uid
       );
       allow create, update, delete: if isSignedIn() && onboardingComplete() && !hasRole('client');
     }
@@ -34,26 +34,32 @@ service cloud.firestore {
     match /invoices/{invoiceId} {
       allow read: if isSignedIn() && onboardingComplete() && (
         hasRole('admin') ||
-        hasRole('freelancer') ||
+        hasRole('employer') ||
         (hasRole('client') && resource.data.clientId == request.auth.uid)
       );
-      allow create, update, delete: if isSignedIn() && onboardingComplete() && (hasRole('admin') || hasRole('freelancer'));
+      allow create, update, delete: if isSignedIn() && onboardingComplete() && (hasRole('admin') || hasRole('employer'));
     }
 
     match /files/{fileId} {
       allow read: if isSignedIn() && onboardingComplete() && (
-        hasRole('admin') || hasRole('freelancer') || resource.data.clientId == request.auth.uid
+        hasRole('admin') || hasRole('employer') || resource.data.clientId == request.auth.uid
       );
-      allow write: if isSignedIn() && onboardingComplete() && (hasRole('admin') || hasRole('freelancer') || hasRole('team_member'));
+      allow write: if isSignedIn() && onboardingComplete() && (hasRole('admin') || hasRole('employer') || hasRole('team_member'));
     }
 
     match /projectRequests/{requestId} {
       allow create: if isSignedIn() && onboardingComplete() && hasRole('client');
       allow read: if isSignedIn() && onboardingComplete() &&
-        (hasRole('admin') || hasRole('freelancer') || resource.data.clientId == request.auth.uid);
-      allow update: if isSignedIn() && onboardingComplete() && (hasRole('admin') || hasRole('freelancer'));
+        (hasRole('admin') || hasRole('employer') || resource.data.clientId == request.auth.uid);
+      allow update: if isSignedIn() && onboardingComplete() && (hasRole('admin') || hasRole('employer'));
       allow delete: if isSignedIn() && onboardingComplete() &&
         (hasRole('admin') || resource.data.clientId == request.auth.uid);
+    }
+
+    match /tasks/{taskId} {
+      allow create: if isSignedIn() && onboardingComplete() && hasRole('employer');
+      allow read: if isSignedIn() && onboardingComplete() && (hasRole('employer') || resource.data.assigneeId == request.auth.uid);
+      allow update, delete: if isSignedIn() && onboardingComplete() && hasRole('employer');
     }
 
     match /{document=**} {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shifter-client-portal",
   "version": "1.0.0",
-  "description": "A client portal for freelancers to manage invoices, projects, and file sharing",
+  "description": "A portal for employers and employees to manage invoices, projects, and file sharing",
   "type": "module",
   "main": "index.js",
   "scripts": {
@@ -40,7 +40,7 @@
     "vite": "^5.0.8"
   },
   "keywords": [
-    "freelancer",
+    "employer",
     "client-portal",
     "invoices",
     "project-management",

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -121,7 +121,7 @@ function Onboarding() {
             <div>
               <h3 className="text-lg font-semibold text-gray-900">Client Access</h3>
               <p className="text-sm text-gray-600 mt-1">
-                I want to hire freelancers and manage projects
+                I want to view and work on projects assigned to me
               </p>
             </div>
             <ul className="text-sm text-gray-600 space-y-2 text-left">

--- a/src/components/ProfileSettings.tsx
+++ b/src/components/ProfileSettings.tsx
@@ -236,11 +236,11 @@ function ProfileSettings() {
             Role
           </label>
           <select
-            value={currentUser?.role || 'freelancer'}
+            value={currentUser?.role || 'employer'}
             onChange={(e) => updateUserRole(e.target.value as any)}
             className="input-field"
           >
-            <option value="freelancer">Freelancer</option>
+            <option value="employer">Employer</option>
             <option value="admin">Admin</option>
             <option value="team_member">Team Member</option>
           </select>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -39,7 +39,7 @@ function Sidebar() {
         { name: 'Settings', href: '/settings', icon: SettingsIcon },
       ];
     } else {
-      // Default navigation for employees/freelancers
+      // Default navigation for employers
       return [
         { name: 'Dashboard', href: '/dashboard', icon: Home },
         { name: 'Invoices', href: '/invoices', icon: FileText },

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -35,7 +35,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
-  async function signup(email: string, password: string, name: string, role: UserRole = 'freelancer') {
+  async function signup(email: string, password: string, name: string, role: UserRole = 'employer') {
     const result = await createUserWithEmailAndPassword(auth, email, password);
     const userRef = doc(db, 'users', result.user.uid);
     const customUser: User = {
@@ -73,7 +73,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         id: result.user.uid,
         email: data.email || '',
         name: data.name || result.user.displayName || 'User',
-        role: data.role || 'freelancer',
+        role: data.role || 'employer',
         permissions: data.permissions || [],
         createdAt: data.createdAt?.toDate?.() || new Date(),
         onboardingCompleted: data.onboardingCompleted || false,
@@ -84,7 +84,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         id: result.user.uid,
         email: result.user.email || '',
         name: result.user.displayName || 'User',
-        role: 'freelancer',
+        role: 'employer',
         permissions: [],
         createdAt: new Date(),
         onboardingCompleted: false,
@@ -141,7 +141,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             id: firebaseUser.uid,
             email: data.email || '',
             name: data.name || firebaseUser.displayName || 'User',
-            role: data.role || 'freelancer',
+            role: data.role || 'employer',
             permissions: data.permissions || [],
             createdAt: data.createdAt?.toDate?.() || new Date(),
             onboardingCompleted: data.onboardingCompleted || false,
@@ -153,7 +153,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             id: firebaseUser.uid,
             email: firebaseUser.email || '',
             name: firebaseUser.displayName || 'User',
-            role: 'freelancer',
+            role: 'employer',
             permissions: [],
             createdAt: new Date(),
             onboardingCompleted: false,

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -127,7 +127,7 @@ function Dashboard() {
           <div className="flex items-center justify-between">
             <div>
               <h3 className="text-lg font-semibold text-blue-900">Ready to start a new project?</h3>
-              <p className="text-blue-700 mt-1">Submit a project request and we'll match you with the perfect freelancer.</p>
+              <p className="text-blue-700 mt-1">Submit a project request and your employer will review it.</p>
             </div>
             <Link
               to="/project-request"

--- a/src/pages/ProjectDashboard.tsx
+++ b/src/pages/ProjectDashboard.tsx
@@ -1,56 +1,172 @@
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { mockTasks, Task } from '../data/mockTasks';
+import { useForm } from 'react-hook-form';
+import { Plus } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { collection, onSnapshot, orderBy, query, where } from 'firebase/firestore';
+import { db } from '../firebase/config';
+import { Task, addTask, docToTask } from '../firebase/tasks';
+import { getClients, Client } from '../firebase/clients';
+import { useAuth } from '../contexts/AuthContext';
+
+interface TaskForm {
+  title: string;
+  assigneeId: string;
+  dueDate: string;
+}
 
 function ProjectDashboard() {
   const { projectId } = useParams();
-  const projectTasks: Task[] = mockTasks.filter(t => t.projectId === projectId);
-  const teamMembers = Array.from(new Set(projectTasks.map(t => t.assignee)));
+  const { currentUser } = useAuth();
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [employees, setEmployees] = useState<Client[]>([]);
+  const [showForm, setShowForm] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<TaskForm>();
+
+  useEffect(() => {
+    if (!projectId) return;
+    const tasksRef = collection(db, 'tasks');
+    const q = query(tasksRef, where('projectId', '==', projectId), orderBy('dueDate', 'asc'));
+    const unsubscribe = onSnapshot(q, snapshot => {
+      setTasks(snapshot.docs.map(docToTask));
+    });
+    return unsubscribe;
+  }, [projectId]);
+
+  useEffect(() => {
+    const fetchEmployees = async () => {
+      if (!currentUser) return;
+      const list = await getClients(currentUser.id);
+      setEmployees(list);
+    };
+    fetchEmployees();
+  }, [currentUser]);
+
+  const onSubmit = async (data: TaskForm) => {
+    if (!projectId) return;
+    const assignee = employees.find(e => e.id === data.assigneeId);
+    try {
+      await addTask({
+        projectId,
+        title: data.title,
+        assigneeId: data.assigneeId,
+        assigneeName: assignee?.name || '',
+        dueDate: data.dueDate,
+      });
+      toast.success('Task created');
+      reset();
+      setShowForm(false);
+    } catch {
+      toast.error('Failed to create task');
+    }
+  };
 
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-bold text-gray-900">Project Dashboard</h1>
       <div className="card space-y-4">
-        <div>
-          <h2 className="text-xl font-semibold text-gray-900">Team Members</h2>
-          {teamMembers.length ? (
-            <ul className="list-disc pl-5 mt-2 space-y-1">
-              {teamMembers.map(member => (
-                <li key={member} className="text-gray-700">{member}</li>
-              ))}
-            </ul>
-          ) : (
-            <p className="text-gray-600">No team members assigned.</p>
+        <div className="flex justify-between items-center">
+          <h2 className="text-xl font-semibold text-gray-900">Tasks</h2>
+          {currentUser?.role === 'employer' && (
+            <button
+              onClick={() => setShowForm(!showForm)}
+              className="btn-primary flex items-center"
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              Add Task
+            </button>
           )}
         </div>
-        <div>
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">Tasks</h2>
-          {projectTasks.length ? (
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Task</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Assignee</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Due Date</th>
-                  </tr>
-                </thead>
-                <tbody className="bg-white divide-y divide-gray-200">
-                  {projectTasks.map(task => (
-                    <tr key={task.id} className="hover:bg-gray-50">
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{task.title}</td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{task.assignee}</td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 capitalize">{task.status.replace('-', ' ')}</td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{task.dueDate}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+
+        {showForm && currentUser?.role === 'employer' && (
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Title</label>
+              <input
+                {...register('title', { required: true })}
+                className="input-field"
+                placeholder="Task title"
+              />
+              {errors.title && (
+                <p className="mt-1 text-sm text-red-600">Title is required</p>
+              )}
             </div>
-          ) : (
-            <p className="text-gray-600">No tasks for this project.</p>
-          )}
-        </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Assign To</label>
+              <select
+                {...register('assigneeId', { required: true })}
+                className="input-field"
+              >
+                <option value="">Select employee</option>
+                {employees.map(emp => (
+                  <option key={emp.id} value={emp.id}>{emp.name}</option>
+                ))}
+              </select>
+              {errors.assigneeId && (
+                <p className="mt-1 text-sm text-red-600">Assignee is required</p>
+              )}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Due Date</label>
+              <input
+                type="date"
+                {...register('dueDate', { required: true })}
+                className="input-field"
+              />
+              {errors.dueDate && (
+                <p className="mt-1 text-sm text-red-600">Due date is required</p>
+              )}
+            </div>
+            <div className="flex justify-end space-x-3">
+              <button
+                type="button"
+                onClick={() => {
+                  setShowForm(false);
+                  reset();
+                }}
+                className="btn-secondary"
+              >
+                Cancel
+              </button>
+              <button type="submit" className="btn-primary">
+                Save Task
+              </button>
+            </div>
+          </form>
+        )}
+
+        {tasks.length ? (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Task</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Assignee</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Due Date</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {tasks.map(task => (
+                  <tr key={task.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{task.title}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{task.assigneeName}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 capitalize">{task.status}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{task.dueDate}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="text-gray-600">No tasks for this project.</p>
+        )}
       </div>
     </div>
   );

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,4 +1,4 @@
-export type UserRole = 'admin' | 'freelancer' | 'client' | 'team_member';
+export type UserRole = 'admin' | 'employer' | 'client' | 'team_member';
 
 export interface User {
   id: string;
@@ -39,7 +39,7 @@ export const ROLE_PERMISSIONS: Record<UserRole, Permission[]> = {
     { resource: 'settings', actions: ['create', 'read', 'update', 'delete'] },
     { resource: 'analytics', actions: ['read'] },
   ],
-  freelancer: [
+  employer: [
     { resource: 'clients', actions: ['create', 'read', 'update'] },
     { resource: 'invoices', actions: ['create', 'read', 'update'] },
     { resource: 'projects', actions: ['create', 'read', 'update'] },


### PR DESCRIPTION
## Summary
- rename freelancer role to employer across app and docs
- allow only employers to create project tasks assigned to employees
- enforce employer-only task writes in Firestore rules

## Testing
- `npm test`
- `npx eslint .`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a08468b01c832a85c48b9cc064c5c2