### PR TITLE
fix: stabilize employee and project creation flows

### DIFF
--- a/src/pages/Employees.tsx
+++ b/src/pages/Employees.tsx
@@ -63,17 +63,19 @@ function Employees() {
       if (editingClient) {
         // Update existing employee
         await updateClient(editingClient.id, data);
-        setClients(clients.map(client =>
-          client.id === editingClient.id
-            ? { ...client, ...data }
-            : client
-        ));
+        setClients(prevClients =>
+          prevClients.map(client =>
+            client.id === editingClient.id
+              ? { ...client, ...data }
+              : client
+          )
+        );
         toast.success('Employee updated successfully!');
       } else {
         // Add new employee
         if (!currentUser) throw new Error('Not authenticated');
         const newClient = await addClient(data, currentUser.id);
-        setClients([newClient, ...clients]);
+        setClients(prevClients => [newClient, ...prevClients]);
         toast.success('Employee added successfully!');
       }
       
@@ -97,7 +99,7 @@ function Employees() {
   const handleDelete = async (clientId: string) => {
     try {
       await deleteClient(clientId);
-      setClients(clients.filter(client => client.id !== clientId));
+      setClients(prevClients => prevClients.filter(client => client.id !== clientId));
       toast.success('Employee deleted successfully!');
     } catch (error) {
       console.error('Error deleting employee:', error);
@@ -300,9 +302,11 @@ function Employees() {
                                 ? 'active'
                                 : newStatus;
                             await updateClientStatus(client.id, finalStatus);
-                            setClients(clients.map(c =>
-                              c.id === client.id ? { ...c, status: finalStatus } : c
-                            ));
+                            setClients(prevClients =>
+                              prevClients.map(c =>
+                                c.id === client.id ? { ...c, status: finalStatus } : c
+                              )
+                            );
                             toast.success(`Employee ${finalStatus}`);
                           } catch (error) {
                             toast.error('Failed to update status');

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -48,21 +48,28 @@ function Projects() {
   } = useForm<ProjectForm>();
 
   const onSubmit = async (data: ProjectForm) => {
-    const { teamMembers, ...rest } = data;
+    const { teamMembers, budget, ...rest } = data;
     const membersArray = teamMembers
       ? teamMembers.split(',').map(m => m.trim()).filter(Boolean)
       : [];
+    const numericBudget = Number(budget);
+    if (Number.isNaN(numericBudget)) {
+      toast.error('Budget must be a number');
+      return;
+    }
 
     try {
       if (editingProject) {
         await updateProject(editingProject.id, {
           ...rest,
+          budget: numericBudget,
           teamMembers: membersArray,
         });
         toast.success('Project updated successfully!');
       } else {
         await addProject({
           ...rest,
+          budget: numericBudget,
           teamMembers: membersArray,
         });
         toast.success('Project created successfully!');
@@ -212,6 +219,7 @@ function Projects() {
                 <input
                   {...register('budget', {
                     required: 'Budget is required',
+                    valueAsNumber: true,
                     min: { value: 0, message: 'Budget must be positive' },
                   })}
                   type="number"


### PR DESCRIPTION
## Summary
- ensure project budget is properly treated as a number and validated on submission
- use functional state updates for employee list to avoid stale state when adding, editing, deleting or toggling status

## Testing
- `npm test`
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f8a81070832aaf2c1d08539df33f