### PR TITLE
Implement offline fallback for task retrieval

### DIFF
--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,18 +1,30 @@
 import { useEffect, useState } from 'react';
 import { collection, onSnapshot, orderBy, query, where } from 'firebase/firestore';
 import { db } from '../firebase/config';
-import { Task, docToTask } from '../firebase/tasks';
+import { Task, docToTask, getTasksForUser } from '../firebase/tasks';
 
 export function useTasks(userId?: string) {
   const [tasks, setTasks] = useState<Task[]>([]);
 
   useEffect(() => {
     if (!userId) return;
+
+    // Initial fetch with offline fallback
+    getTasksForUser(userId).then(setTasks).catch(() => {
+      setTasks([]);
+    });
+
     const tasksRef = collection(db, 'tasks');
     const q = query(tasksRef, where('assigneeId', '==', userId), orderBy('dueDate', 'asc'));
-    const unsubscribe = onSnapshot(q, snapshot => {
-      setTasks(snapshot.docs.map(docToTask));
-    });
+    const unsubscribe = onSnapshot(
+      q,
+      snapshot => {
+        setTasks(snapshot.docs.map(docToTask));
+      },
+      () => {
+        // Ignore errors here – initial fetch already handled fallback
+      }
+    );
 
     return unsubscribe;
   }, [userId]);


### PR DESCRIPTION
## Summary
- ensure `useTasks` loads tasks from local storage when Firestore is unavailable
- maintain snapshot listener for realtime updates when online

## Testing
- `npm test`
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*

------
https://chatgpt.com/codex/tasks/task_e_68a3708ed8b4832a8ee1ecdfa7902f52