### PR TITLE
Allow employers to view all tasks

### DIFF
--- a/src/firebase/tasks.ts
+++ b/src/firebase/tasks.ts
@@ -73,15 +73,21 @@ export const docToTask = (
   };
 };
 
-export const getTasksForUser = async (userId: string): Promise<Task[]> => {
+export const getTasksForUser = async (
+  userId?: string,
+  isEmployer = false
+): Promise<Task[]> => {
   try {
     const tasksRef = collection(db, 'tasks');
-    const q = query(tasksRef, where('assigneeId', '==', userId), orderBy('dueDate', 'asc'));
+    const q = isEmployer
+      ? query(tasksRef, orderBy('dueDate', 'asc'))
+      : query(tasksRef, where('assigneeId', '==', userId), orderBy('dueDate', 'asc'));
     const snapshot = await getDocs(q);
     return snapshot.docs.map(docToTask);
   } catch (error) {
     console.error('Error fetching tasks:', error);
-    return loadLocalTasks().filter(t => t.assigneeId === userId);
+    const tasks = loadLocalTasks();
+    return isEmployer ? tasks : tasks.filter(t => t.assigneeId === userId);
   }
 };
 

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -5,7 +5,10 @@ import { Task, updateTaskStatus } from '../firebase/tasks';
 
 function Tasks() {
   const { currentUser } = useAuth();
-  const tasks: Task[] = useTasks(currentUser?.id);
+  const tasks: Task[] = useTasks(
+    currentUser?.id,
+    currentUser?.role === 'employer'
+  );
 
   const handleStatusChange = async (
     taskId: string,
@@ -21,7 +24,9 @@ function Tasks() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-bold text-gray-900">My Tasks</h1>
+      <h1 className="text-2xl font-bold text-gray-900">
+        {currentUser?.role === 'employer' ? 'All Tasks' : 'My Tasks'}
+      </h1>
       <div className="card">
         {tasks.length ? (
           <div className="overflow-x-auto">


### PR DESCRIPTION
## Summary
- support employers in `useTasks` and tasks fetching
- display all tasks for employers on the Tasks page

## Testing
- `npm test`
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68a4eb3207a8832ab0380740eadf85da