### PR TITLE
Track employer ownership of tasks

### DIFF
--- a/src/components/CreateTask.tsx
+++ b/src/components/CreateTask.tsx
@@ -59,6 +59,7 @@ function CreateTask() {
         title: data.title,
         assigneeId: data.assigneeId,
         assigneeName: assignee?.name || '',
+        ownerId: currentUser?.id || '',
         dueDate,
       });
       toast.success('Task created successfully!');

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -7,7 +7,7 @@ export function useTasks(userId?: string, isEmployer = false) {
   const [tasks, setTasks] = useState<Task[]>([]);
 
   useEffect(() => {
-    if (!userId && !isEmployer) return;
+    if (!userId) return;
 
     // Initial fetch with offline fallback
     getTasksForUser(userId, isEmployer)
@@ -18,7 +18,7 @@ export function useTasks(userId?: string, isEmployer = false) {
 
     const tasksRef = collection(db, 'tasks');
     const q = isEmployer
-      ? query(tasksRef, orderBy('dueDate', 'asc'))
+      ? query(tasksRef, where('ownerId', '==', userId), orderBy('dueDate', 'asc'))
       : query(tasksRef, where('assigneeId', '==', userId), orderBy('dueDate', 'asc'));
     const unsubscribe = onSnapshot(
       q,

--- a/src/pages/ProjectDashboard.tsx
+++ b/src/pages/ProjectDashboard.tsx
@@ -61,6 +61,7 @@ function ProjectDashboard() {
         title: data.title,
         assigneeId: data.assigneeId,
         assigneeName: assignee?.name || '',
+        ownerId: currentUser?.id || '',
         dueDate: data.dueDate,
       });
       toast.success('Task created');


### PR DESCRIPTION
## Summary
- record `ownerId` on every task
- scope employer task queries by owner
- include owner ID when creating new tasks

## Testing
- `npm test`
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68a4faa2ae90832a830a9ccfe7dc7b1c